### PR TITLE
Add margin to changelog entries in blog list

### DIFF
--- a/src/css/pages/page-blog.css
+++ b/src/css/pages/page-blog.css
@@ -68,7 +68,7 @@
     padding: 0 0 0 4rem;
   }
 
-  .blog-post {
+  .blog-post, .doc {
     margin-bottom: 6rem;
     max-width: 600px;
   }


### PR DESCRIPTION
While browsing the blog I noticed the changelog entries sitting on top of the next blog entry. Proposed change is merely to add consistency throughout the list.

**EDIT** To clarify, I was viewing not the default blog list but the tag-filtered one, as seen here: https://forestry.io/categories/cms/

So this change should only affect all `.doc` elements that are listed within `.section-blog-list`