### PR TITLE
Use bin name instead of relative path in scripts

### DIFF
--- a/hugo/content/blog/write-better-javascript-with-webpack.md
+++ b/hugo/content/blog/write-better-javascript-with-webpack.md
@@ -160,8 +160,8 @@ The default `package.json` comes with one script called `test` that just returns
     ...
     "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "./node_modules/webpack-cli/bin/webpack.js",
-    "watch": "./node_modules/webpack-cli/bin/webpack.js --watch"
+    "build": "webpack",
+    "watch": "webpack --watch"
     },
     ...
 }


### PR DESCRIPTION
Specifying

```
"build": "./node_modules/webpack-cli/bin/webpack.js"
```

in a `package.json` script is unnecessarily verbose. When you run a script, npm adds binaries from the local `node_modules/` to the `PATH`. Therefore, you can simply write

```
"build": "webpack"
```