### PR TITLE
Fix Unnecessary Author Bio Link Redirect

### DIFF
--- a/hugo/layouts/blog/single.html
+++ b/hugo/layouts/blog/single.html
@@ -19,7 +19,7 @@
             {{- $authorName := . -}}
             {{- range $.Site.Data.authors.authors -}}
               {{- if eq (urlize .fullName) (urlize $authorName) -}}
-              <a href="{{ "/authors/" | relURL }}{{ .fullName | urlize }}" class="author--wrapper">
+              <a href="{{ "/authors/" | relURL }}{{ .fullName | urlize }}/" class="author--wrapper">
                 <div class="author--avatar">
                   <img src="{{ .avatar }}" alt="{{ .fullName | default .avatar }}">
                 </div>


### PR DESCRIPTION
I noticed all author bios have a missing forward slash which causes an unnecessary redirect and probably a few milliseconds of time.

For example: My bio link on my posts is`https://forestry.io/authors/colin-garvey` which redirects to `https://forestry.io/authors/colin-garvey/`.