### PR TITLE
Change increase from 600% to 500%

### DIFF
--- a/hugo/content/blog/for-static-sites-theres-no-excuse-not-to-use-a-cdn.md
+++ b/hugo/content/blog/for-static-sites-theres-no-excuse-not-to-use-a-cdn.md
@@ -64,7 +64,7 @@ By changing the hostname in my command from `ec2.us-east-1.amazonaws.com` to `ec
     PING ec2.ap-southeast-2.amazonaws.com (54.240.195.243) 56(84) bytes of data. 
     64 bytes from 54.240.195.243: icmp_seq=1 ttl=233 time=301 ms
 
-Communicating with the more distant server caused a _600% increase_ in round-trip latency. 250 milliseconds may sound like a short amount of time, but this time penalty applies to _every request_ the user makes to that server: CSS, JavaScript, images, etc. Even [small amounts of latency can negatively impact your site](https://blog.gigaspaces.com/amazon-found-every-100ms-of-latency-cost-them-1-in-sales/). If there were an easy way to eliminate this latency, wouldn’t you want to do it?
+Communicating with the more distant server caused a _500% increase_ in round-trip latency. 250 milliseconds may sound like a short amount of time, but this time penalty applies to _every request_ the user makes to that server: CSS, JavaScript, images, etc. Even [small amounts of latency can negatively impact your site](https://blog.gigaspaces.com/amazon-found-every-100ms-of-latency-cost-them-1-in-sales/). If there were an easy way to eliminate this latency, wouldn’t you want to do it?
 
 {{% tip %}}
 If you want to experiment with pinging other regions, take a look at this [chart of EC2 regions](http://ec2-reachability.amazonaws.com/). You can ping the IP address directly, or use a hostname following the convention `ec2.$REGION.amazonaws.com`.


### PR DESCRIPTION
While the timing of the two pings have a relationship of the initial being 100% and the second being 600% of that value, The increase from the first to the second is ~498.40 %.  This is why I have changed from 600% to 500% -- to be more correct.