### PR TITLE
Hide page snippet

### DIFF
--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -56,6 +56,6 @@
 h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
 (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);
 })(window,document.documentElement,'async-hide','dataLayer',4000,{'GTM-KL5HP9Q':true});
-</script>
+</script> 
 <!-- End Page Hiding Snippet -->
 {{- end -}}

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -49,4 +49,13 @@
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','{{ . }}');</script>
 <!-- End Google Tag Manager -->
+<!-- Page Hiding Snippet (recommended) -->
+<style>.async-hide { opacity: 0 !important} </style>
+<script>
+(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;
+h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
+(a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);
+})(window,document.documentElement,'async-hide','dataLayer',4000,{'GTM-KL5HP9Q':true});
+</script>
+<!-- End Page Hiding Snippet -->
 {{- end -}}

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -42,13 +42,6 @@
 {{- end -}}
 {{/* TODO: canonical + multilingual meta */}}
 {{- with $.Site.Params.gtmid -}}
-<!-- Google Tag Manager -->
-<script>
-  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','{{ . }}');</script>
-<!-- End Google Tag Manager -->
 <!-- Page Hiding Snippet (recommended) -->
 <style>.async-hide { opacity: 0 !important} </style>
 <script>
@@ -58,4 +51,11 @@ h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
 })(window,document.documentElement,'async-hide','dataLayer',4000,{'GTM-KL5HP9Q':true});
 </script> 
 <!-- End Page Hiding Snippet -->
+<!-- Google Tag Manager -->
+<script>
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','{{ . }}');</script>
+<!-- End Google Tag Manager -->
 {{- end -}}


### PR DESCRIPTION
This snippet is added to reduce the risk of page flicker when running experiments with Google Optimize and Tag Manager.

I implemented them according to these best practices in snippet order 
👉 https://support.google.com/optimize/answer/7359264?hl=en