### PR TITLE
Scheme example for WYSIWYG format selection

### DIFF
--- a/hugo/content/docs/settings/fields/textarea.md
+++ b/hugo/content/docs/settings/fields/textarea.md
@@ -93,6 +93,19 @@ This field appears when _WYSIWYG_ is enabled. Select which format should be outp
 * **HTML**
 * **Inline HTML** (only inline elements allowed)
 
+### Example
+
+    type: textarea
+    name: description
+    label: Description
+    description: Short description of the page
+    hidden: false
+    default: ""
+    config:
+      wysiwyg: true
+      schema:
+        format: markdown
+
 ## Field UI
 
 ![](/uploads/2018/01/textarea-wysiwyg-preview.png)


### PR DESCRIPTION
It's been great to be able to create FMT in code and pushing up. Noticed there was not an example of how to set the format of the editor and felt it might be nice to include in some way.