### PR TITLE
Change algolia dispatch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
               npm run preDeploy
             else
               npm run build
+            fi
 
       - run:
           name: Create Artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,10 @@ jobs:
       - run:
           name: Run build
           command: |
-            npm run build
+            if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
+              npm run preDeploy
+            else
+              npm run build
 
       - run:
           name: Create Artifacts

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -109,7 +109,7 @@ gulp.task("algolia", cb => {
         const indexName = basename(dirname(file.path))
 
         atomicalgolia(indexName, file.path, function(err, res) {
-          if (err) return
+          if (err) throw err
 
           var count = res.objectIDs.length
           var message = `Sent ${count} operations to ${indexName}...`

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -48,6 +48,15 @@ gulp.task("generator", cb => build(cb))
  * compiles the static site with Hugo
  */
 gulp.task("build", ["clean"], cb => {
+  runsequence(["styles", "scripts", "images", "svg"], "generator", cb)
+})
+
+/**
+ * @task preDeploy
+ * Same as build, but also submits
+ * search index to algolia
+ */
+gulp.task("preDeploy", ["clean"], cb => {
   runsequence(["styles", "scripts", "images", "svg"], "generator", "algolia", cb)
 })
 
@@ -100,7 +109,7 @@ gulp.task("algolia", cb => {
         const indexName = basename(dirname(file.path))
 
         atomicalgolia(indexName, file.path, function(err, res) {
-          if (err) throw err
+          if (err) return
 
           var count = res.objectIDs.length
           var message = `Sent ${count} operations to ${indexName}...`

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -57,7 +57,7 @@ gulp.task("build", ["clean"], cb => {
  * search index to algolia
  */
 gulp.task("preDeploy", ["clean"], cb => {
-  runsequence(["styles", "scripts", "images", "svg"], "generator", "algolia", cb)
+  runsequence("build", "algolia", cb)
 })
 
 /**

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "gulp server",
     "preview": "cross-env NODE_ENV=production GENERATOR_ARGS=preview gulp server",
     "build": "cross-env NODE_ENV=production gulp build",
+    "preDeploy": "cross-env NODE_ENV=production gulp preDeploy",
     "clean": "gulp clean",
     "eslint": "./node_modules/eslint/bin/eslint.js src/js/ --ext .js",
     "eslint:fix": "./node_modules/eslint/bin/eslint.js src/js/ --ext .js --fix",


### PR DESCRIPTION
We stumbled upon an issue a little while ago where, if you have non-draft content in branches other than master, CircleCI will still publish that content to the algolia search index when the commit builds. This can result in content appearing in search results that isn't actually available on the production site.

IMO, sending the search index to algolia is a pretty significant side effect for a script labeled "build". However, I realized that this action is dependent on the search index being built in the first place, so it does make sense to execute it at a specific point in the build process.

The solution I've come up with is to remove algolia from the `build` command and create a new `preDeploy` command that runs algolia after build. This makes it simple to run either/or depending on the value of `$CIRCLE_BRANCH` which is the same check we're doing to determine whether to deploy the site to production