### PR TITLE
correct documentation for usage of headless bundle

### DIFF
--- a/hugo/content/blog/how-to-use-hugo-s-image-processing-with-forestry.md
+++ b/hugo/content/blog/how-to-use-hugo-s-image-processing-with-forestry.md
@@ -31,7 +31,7 @@ aliases: []
 
 In order for this to work, Hugo needs to think we have a content type called `uploads`, so that it can browse this section and locate subresources.
 
-Create a folder in your `content/` directory called `uploads`, and add a file named `_index.md` with the following content:
+Create a folder in your `content/` directory called `uploads`, and add a file named `index.md` with the following content:
 
 ``` yaml
 ---


### PR DESCRIPTION
See Hugo docs: https://gohugo.io/content-management/page-bundles/#headless-bundle

"Only leaf bundles can be made headless."

GetPage and Resources.GetMatch work either way, but Hugo will render the section if `_index.md` is used rather than `index.md`, regardless of headless param.