### PR TITLE
Add link to Roadmap in footer

### DIFF
--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -57,6 +57,11 @@ parent = "Product"
 url = "https://status.forestry.io"
 weight = 6
 [[menu.footer]]
+name = "Roadmap"
+parent = "Product"
+url = "https://portal.productboard.com/forestry/"
+weight = 7
+[[menu.footer]]
 name = "Company"
 weight = 2
 [[menu.footer]]


### PR DESCRIPTION
As discussed with @scottgallant, adding a link to our Product Board Roadmap in the footer.