### PR TITLE
Fix: Cloudinary name

### DIFF
--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -123,9 +123,9 @@ mixpanelid = "8aaf5d792dd5bf875adae0b2adac8900"
 params = ["tags", "categories", "authors"]
 vars = ["date", "description", "dir", "path", "expirydate", "fuzzywordcount", "keywords", "kind", "lang", "lastmod", "permalink", "publishdate", "readingtime", "relpermalink", "summary", "title", "type", "url", "weight", "wordcount", "section"]
 [params.cloudinary]
-cloud_name = "forestry-demo"
+cloud_name = "forestry-io"
 use_upload = false
-baseurl = "https://res.cloudinary.com/forestry-demo/image/fetch"
+baseurl = "https://res.cloudinary.com/forestry-io/image/fetch"
 [params.cloudinary.lazysizes]
 enabled = true
 [params.cloudinary.presets.content]


### PR DESCRIPTION
What is the production cloudinary account?

Some images respond to forestry-demo, others to forestry-io.