### PR TITLE
Update Gridsome build command in build-commands.md

### DIFF
--- a/hugo/content/docs/previews/build-commands.md
+++ b/hugo/content/docs/previews/build-commands.md
@@ -242,7 +242,7 @@ Adapt those commands if you site source lives in a subfolder.
 {{% tab "Gridsome" %}}
 
     "scripts": {
-      "forestry:preview": "gridsome develop -H 0.0.0.0 -p 8080"
+      "forestry:preview": "gridsome develop -h 0.0.0.0 -p 8080"
     }
 
 


### PR DESCRIPTION
update preview build command for Gridsome from `gridsome develop -H 0.0.0.0 -p 8080` to `gridsome develop -h 0.0.0.0 -p 8080`

When I tried running `gridsome develop -H 0.0.0.0 -p 8080` 
I got this error:
```bash
error: unknown option `-H'
```
I had to swap out the `-H` for `-h` before it worked.