### PR TITLE
Textarea field: add the format configuration

### DIFF
--- a/hugo/content/docs/settings/fields/textarea.md
+++ b/hugo/content/docs/settings/fields/textarea.md
@@ -75,7 +75,7 @@ You can configure this field in _Front Matter Template_ [Config Files](/docs/set
     config:
       wysiwyg: [true|false]
       schema:
-        format: [markdown|html|inline_html]
+        format: [markdown|html|html-blocks]
 
 ## Example
 

--- a/hugo/content/docs/settings/fields/textarea.md
+++ b/hugo/content/docs/settings/fields/textarea.md
@@ -74,6 +74,8 @@ You can configure this field in _Front Matter Template_ [Config Files](/docs/set
     default: [String]
     config:
       wysiwyg: [true|false]
+      schema:
+        format: [markdown|html|inline_html]
 
 ## Example
 


### PR DESCRIPTION
The example configuration was missing the `schema.format` key.
Please double check that it is correct as I don't know if it's `snake case` (`inline_html`) or camelCase (`inlineHtml`).
This way it will be more clear on which formatting options are available