### PR TITLE
Update s3.md to contain Forestry 3rd Party Credentials Security Fix

### DIFF
--- a/hugo/content/docs/media/s3.md
+++ b/hugo/content/docs/media/s3.md
@@ -45,6 +45,20 @@ Forestry supports storing your media in your own [AWS S3 bucket](https://docs.aw
 
 Currently, Forestry needs to be able to upload public objects to your S3 bucket in order to display them in the media library (_see Step 4_). We plan to remove this requirement in a future update.
 
+### Forestry.io 3rd Party Credentials Security Vulnerability and How to Fix It
+
+Forestry.io commits a .forestry/settings.yml to your repo branch. This file contains the above **Access key ID** and **Secret access key**, leaving your credentials exposed for anyone who accesses your repo to access your AWS Account.
+
+In order to fix this issue
+1. Delete the branch you have already connected to Forestry.io. (If you do not do that, then github will maintain a history that will include your keys.)
+1. Recreate the branch in github.
+1. Update the branch's `.gitignore` file to include `.forestry/settings.yml`.
+1. Reconnect the branch to Forestry.io.
+
+Now your credentials are never exposed in Github. If by chance, your credentials have been exposed, you'll have to [rotate your AWS access key credentials](https://aws.amazon.com/blogs/security/what-to-do-if-you-inadvertently-expose-an-aws-access-key/) and follow the above steps to fix this issue.
+
+Once you do that than this vulnerability has been secured.
+
 {{% /warning%}}
 
 ## Recommended Path Settings


### PR DESCRIPTION
The app generated file, `.forestry/settings.yml`, exposes AWS credentials, and likely other 3rd party credentials. This is a security vulnerability that needs a fix.

One proposed solution is to instruct the user of Forestry.io to add the .forestry/settings.yml to their repo's `.gitignore` file.

I suspect that Forestry.io holds a table of credentials somewhere, and then writes those credentials to the repo. I think a better solution than instructing a user to update their .gitignore is to update the Forestry.io software to not commit keys/secrets to github.

https://www.datree.io/resources/secrets-management-aws#:~:text=2%20%E2%80%93%20NEVER%20commit%20secrets%20into%20your%20Git%20repositories,-When%20there%20are&text=Even%20worse%2C%20when%20the%20code,stolen%2C%20you%20will%20be%20compromised.

Please note that this vulnerability, if not addressed, can be a show stopper from using your platform but if it WERE addressed, makes you an extremely competitive offering because other markdown editing clients don't allow users to easily connect to S3.