### PR TITLE
Add port number to Gatsby preview command

### DIFF
--- a/hugo/content/docs/previews/instant-previews.md
+++ b/hugo/content/docs/previews/instant-previews.md
@@ -71,7 +71,7 @@ vuepress dev
 {{% tab "Gatsby" %}}
 
 ```bash
-gatsby develop
+gatsby develop -p 8080
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
Relates to support request solved by @DirtyF. Gatsby starts on port 8000 by default, so specifying the port is required for previews.

> I see you were running Gatsby on default port 8000 and you're getting a 504 network error, our network layer do not seem to manage to redirect port 8000 to port 8080, it means you have to pass gatsby develop the port option to force running on 8080.