### PR TITLE
Add missing media storage options to media list page

### DIFF
--- a/hugo/content/docs/media.md
+++ b/hugo/content/docs/media.md
@@ -1,7 +1,7 @@
 ---
 title: Storing Media Files
 weight: 1
-date: '2018-05-25T20:00:00.000+00:00'
+date: '2020-12-20T10:00:00.000+00:00'
 publishdate: 2019-04-14T22:00:00+00:00
 menu:
   docs:

--- a/hugo/content/docs/media.md
+++ b/hugo/content/docs/media.md
@@ -19,10 +19,22 @@ The most basic option for storing media is to commit it to your git repo like th
 If your site has a large number of media files, we highly recommend [implementing Git LFS on your repository](https://forestry.io/blog/versioning-large-files-with-git-lfs/). Forestry will be able to handle Git LFS media for repositories hosted on GitHub and GitLab.
 {{% /warning %}}
 
-[Read the full guide on using Git for media storage](/docs/media/git)
+[Read the full guide on using Git for media storage](/docs/media/git/)
 
 ## Cloudinary
 
 Forestry can use [Cloudinary](https://cloudinary.com/) to store your media files. With Cloudinary, you have the advantage of easy image manipulation directly in your templates.
 
-[Read the full guide on using Cloudinary for media storage](/docs/media/cloudinary)
+[Read the full guide on using Cloudinary for media storage](/docs/media/cloudinary/)
+
+## AWS S3
+
+Forestry can use an [AWS S3 Bucket](/docs/media/s3/) to store your media files. With AWS S3, you can completely customize your image storage, image processing, and handling. 
+
+[Read the full guide on using AWS S3 for media storage](/docs/media/s3/)
+
+## Netlify Large Media
+
+Forestry can integrate with [Netlify Large Media](https://www.netlify.com/docs/large-media/) for storing your uploads. Netlify Large Media is a Git LFS target, enabling you to seamlessly incorporate large media files in your repository without the performance penalty that this usually requires.
+
+[Read the full guide on using Netlify Large Media for media storage](/docs/media/netlify-large-media/)


### PR DESCRIPTION
## Background
The side bar of the Forestry docs mentions S3 and Netlify Large Media as media storage options. This PR adds them to the list page for Storing Media Files.

### Old version of Storing Media Files page
![image](https://user-images.githubusercontent.com/12521775/102717774-55180880-4299-11eb-96a3-6d1e660e3abf.png)

### New version of Storing Media Files page
![image](https://user-images.githubusercontent.com/12521775/102717771-4f222780-4299-11eb-9944-ffcff3dfb8d8.png)

### Old version of menu ![image](https://user-images.githubusercontent.com/12521775/102717657-8c39ea00-4298-11eb-8d59-1424e2d833a7.png)

### New version of menu
![image](https://user-images.githubusercontent.com/12521775/102717755-2b5ee180-4299-11eb-8104-a6833ceed9df.png)

I also added the missing trailing slashes on this page to prevent a bunch of small redirects for users.