### PR TITLE
setup ruby before installing htmlproofer gem

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -38,6 +38,9 @@ jobs:
           npm run build
           tar -zcvf dist.tar.gz ./dist
       
+      - uses: ruby/setup-ruby
+        with:
+          ruby-version: 2.x
       - name: Test html
         run: |
           sudo gem install html-proofer -v 3.19.1


### PR DESCRIPTION
it appears that the gem install is failing due to
incomplete platform metadata, this is an attempt
to fix