### PR TITLE
Clarify that Forestry will install Remote Admin file at Admin Path

### DIFF
--- a/hugo/content/docs/editing/remote-admin.md
+++ b/hugo/content/docs/editing/remote-admin.md
@@ -29,7 +29,7 @@ Select the _General_ tab, and find the Project Paths option. From here you provi
 
 ![](/uploads/2018/01/settings-projectpaths.png)
 
-The Remote Admin is deployed as a static HTML page, so be sure you deploy it to a path that will be treated as a [static file](/docs/faqs/glossary/static-files/) by your static site generator.
+Forestry will install a static HTML file that powers the Remote Admin at the Admin Path, so be sure to set it to a path that will be treated as a [static file](/docs/faqs/glossary/static-files/) by your static site generator.
 
 ### Examples
 


### PR DESCRIPTION
The phrasing 'the Remote Admin is deployed as a static HTML page' confused me because of the passive voice. I wasn't sure if I needed to manually add the static file myself. Explaining that "Forestry will install a static HTML file" clears that up. (Such a cool feature, BTW!)