### PR TITLE
Replaced broken link with alternative

### DIFF
--- a/hugo/content/blog/5-ways-to-handle-forms-on-your-static-site.md
+++ b/hugo/content/blog/5-ways-to-handle-forms-on-your-static-site.md
@@ -44,7 +44,7 @@ The options presented here range from fully-managed solutions for lean teams, al
 
 **Update**: While those options remain viable, other forms services were created since. Check also:
 
-- [StaticKit](https://statickit.com/)
+- [Web3Forms](https://web3forms.com/)
 - [Formik](https://formik.com)
 - [Other Forms services](https://serverless.css-tricks.com/services/forms)
 


### PR DESCRIPTION
https://statickit.com/ returns `404` error. So replaced it with a similar alternative.